### PR TITLE
Add optional context argument

### DIFF
--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -50,8 +50,10 @@ var position = function(start, end, elapsed, duration) {
 // if the first argument is an element then scroll to the top of this element
 // if the first argument is numeric then scroll to this location
 // if the callback exist, it is called when the scrolling is finished
-var smoothScroll = function(el, duration, callback){
+// if context is set then scroll within that element, else scroll window 
+var smoothScroll = function(el, duration, callback, context){
     duration = duration || 500;
+    context = context || window;
     var start = window.pageYOffset;
 
     if (typeof el === 'number') {
@@ -67,7 +69,13 @@ var smoothScroll = function(el, duration, callback){
 
     var step = function(){
         var elapsed = Date.now() - clock;
-        window.scroll(0, position(start, end, elapsed, duration));
+        if (context != window) {
+        	context.scrollTop = position(start, end, elapsed, duration);
+        }
+        else {
+        	window.scroll(0, position(start, end, elapsed, duration));
+        }
+
         if (elapsed > duration) {
             if (typeof callback === 'function') {
                 callback(el);


### PR DESCRIPTION
Added optional context argument to scroll element instead of window.

For example, let's say you have a fixed height container with a larger element inside:
```html
<div id="container" style="height: 100px; overflow-y: scroll;">
    <div id="element" style="height: 1000px;"></div>
</div>
```

You can now call:
 ```javascript
var el = document.querySelector('#element').scrollHeight;
var duration = 1000;
var callback = null;
var context = document.querySelector('#element');
smoothScroll(el, duration, callback, context);
``` 
to scroll to bottom of container.