### PR TITLE
make attachment to all links opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Just include smoothscroll inside your page, like this:
 
     <script type="text/javascript" src="path/to/smoothscroll.min.js"></script>
 
-All your internal links will be tied to a smooth scroll.
+If you want all links to be automatically tied to smooth scroll, call the following:
+`window.smoothScroll.attachToAllLinks()`
+
 If you want to call a smooth scroll from your code, you can now use the API by calling:
 
 `window.smoothScroll(target, duration, callback, context)`

--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -87,27 +87,29 @@ var smoothScroll = function(el, duration, callback, context){
     step();
 }
 
-var linkHandler = function(ev) {
-    ev.preventDefault();
-
-    if (location.hash !== this.hash) window.history.pushState(null, null, this.hash)
-    // using the history api to solve issue #1 - back doesn't work
-    // most browser don't update :target when the history api is used:
-    // THIS IS A BUG FROM THE BROWSERS.
-    // change the scrolling duration in this call
-    smoothScroll(document.getElementById(this.hash.substring(1)), 500, function(el) {
-        location.replace('#' + el.id)
-        // this will cause the :target to be activated.
+smoothScroll.attachToAllLinks = function() {
+    var linkHandler = function(ev) {
+      ev.preventDefault();
+  
+      if (location.hash !== this.hash) window.history.pushState(null, null, this.hash)
+      // using the history api to solve issue #1 - back doesn't work
+      // most browser don't update :target when the history api is used:
+      // THIS IS A BUG FROM THE BROWSERS.
+      // change the scrolling duration in this call
+      smoothScroll(document.getElementById(this.hash.substring(1)), 500, function(el) {
+          location.replace('#' + el.id)
+          // this will cause the :target to be activated.
+      });
+    }
+  
+    // We look for all the internal links in the documents and attach the smoothscroll function
+    document.addEventListener("DOMContentLoaded", function () {
+        var internal = document.querySelectorAll('a[href^="#"]:not([href="#"])'), a;
+        for(var i=internal.length; a=internal[--i];){
+            a.addEventListener("click", linkHandler, false);
+        }
     });
 }
-
-// We look for all the internal links in the documents and attach the smoothscroll function
-document.addEventListener("DOMContentLoaded", function () {
-    var internal = document.querySelectorAll('a[href^="#"]:not([href="#"])'), a;
-    for(var i=internal.length; a=internal[--i];){
-        a.addEventListener("click", linkHandler, false);
-    }
-});
 
 // return smoothscroll API
 return smoothScroll;


### PR DESCRIPTION
The code that attaches to all links is throwing an exception on my site.  Besides, I didn't want that automatically; I just wanted to be able to call smoothScroll programmatically.  In my opinion attaching smooth scrolling to all links should be an opt-in feature, not the default.