### PR TITLE
fix multiple issues with non-window scrolling context

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Just include smoothscroll inside your page, like this:
 
     <script type="text/javascript" src="path/to/smoothscroll.min.js"></script>
 
-All your internal links will be tied to a smooth scroll.
+If you want all links to be automatically tied to smooth scroll, call the following:
+`window.smoothScroll.attachToAllLinks()`
+
 If you want to call a smooth scroll from your code, you can now use the API by calling:
 
 `window.smoothScroll(target, duration, callback, context)`

--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -87,27 +87,29 @@ var smoothScroll = function(el, duration, callback, context){
     step();
 }
 
-var linkHandler = function(ev) {
-    ev.preventDefault();
-
-    if (location.hash !== this.hash) window.history.pushState(null, null, this.hash)
-    // using the history api to solve issue #1 - back doesn't work
-    // most browser don't update :target when the history api is used:
-    // THIS IS A BUG FROM THE BROWSERS.
-    // change the scrolling duration in this call
-    smoothScroll(document.getElementById(this.hash.substring(1)), 500, function(el) {
-        location.replace('#' + el.id)
-        // this will cause the :target to be activated.
+smoothScroll.attachToAllLinks = function() {
+    var linkHandler = function(ev) {
+      ev.preventDefault();
+  
+      if (location.hash !== this.hash) window.history.pushState(null, null, this.hash)
+      // using the history api to solve issue #1 - back doesn't work
+      // most browser don't update :target when the history api is used:
+      // THIS IS A BUG FROM THE BROWSERS.
+      // change the scrolling duration in this call
+      smoothScroll(document.getElementById(this.hash.substring(1)), 500, function(el) {
+          location.replace('#' + el.id)
+          // this will cause the :target to be activated.
+      });
+    }
+  
+    // We look for all the internal links in the documents and attach the smoothscroll function
+    document.addEventListener("DOMContentLoaded", function () {
+        var internal = document.querySelectorAll('a[href^="#"]:not([href="#"])'), a;
+        for(var i=internal.length; a=internal[--i];){
+            a.addEventListener("click", linkHandler, false);
+        }
     });
 }
-
-// We look for all the internal links in the documents and attach the smoothscroll function
-document.addEventListener("DOMContentLoaded", function () {
-    var internal = document.querySelectorAll('a[href^="#"]:not([href="#"])'), a;
-    for(var i=internal.length; a=internal[--i];){
-        a.addEventListener("click", linkHandler, false);
-    }
-});
 
 // return smoothscroll API
 return smoothScroll;

--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -67,6 +67,9 @@ var smoothScroll = function(el, duration, callback, context){
       var end = getTop(el, context);
     }
 
+    let endContext = context === window ? document.body : context;
+    end = Math.min(end, endContext.scrollHeight - endContext.offsetHeight);
+
     var clock = Date.now();
     var requestAnimationFrame = window.requestAnimationFrame ||
         window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame ||

--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -59,7 +59,7 @@ var position = function(start, end, elapsed, duration) {
 var smoothScroll = function(el, duration, callback, context){
     duration = duration || 500;
     context = context || window;
-    var start = window.pageYOffset;
+    var start = context === window ? window.pageYOffset : context.scrollTop;
 
     if (typeof el === 'number') {
       var end = el;

--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -34,7 +34,7 @@ var getTop = function(element, context) {
         return element.getBoundingClientRect().top + window.pageYOffset;
     }
     else {
-        return element.getBoundingClientRect().top - context.getBoundingClientRect().top;
+        return element.getBoundingClientRect().top - context.getBoundingClientRect().top + context.scrollTop;
     }
 }
 // ease in out function thanks to:

--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -27,10 +27,15 @@ if (typeof window !== 'object') return;
 if(document.querySelectorAll === void 0 || window.pageYOffset === void 0 || history.pushState === void 0) { return; }
 
 // Get the top position of an element in the document
-var getTop = function(element) {
-    // return value of html.getBoundingClientRect().top ... IE : 0, other browsers : -pageYOffset
-    if(element.nodeName === 'HTML') return -window.pageYOffset
-    return element.getBoundingClientRect().top + window.pageYOffset;
+var getTop = function(element, context) {
+    if (context === window) {
+        // return value of html.getBoundingClientRect().top ... IE : 0, other browsers : -pageYOffset
+        if(element.nodeName === 'HTML') return -window.pageYOffset
+        return element.getBoundingClientRect().top + window.pageYOffset;
+    }
+    else {
+        return element.getBoundingClientRect().top - context.getBoundingClientRect().top;
+    }
 }
 // ease in out function thanks to:
 // http://blog.greweb.fr/2012/02/bezier-curve-based-easing-functions-from-concept-to-implementation/
@@ -57,9 +62,9 @@ var smoothScroll = function(el, duration, callback, context){
     var start = window.pageYOffset;
 
     if (typeof el === 'number') {
-      var end = parseInt(el);
+      var end = el;
     } else {
-      var end = getTop(el);
+      var end = getTop(el, context);
     }
 
     var clock = Date.now();


### PR DESCRIPTION
This fixes the following issues when scrolling with a context besides the window:

* it was using 0 for the start position instead of the context's `scrollTop`
* it wasn't determining the end position correctly (should be `el.getBoundingClientRect().top - context.getBoundingClientRect().top + context.scrollTop`)
* smooth scrolling to the end wouldn't ease out in some cases.  Solution: clamp the end position to `context.scrollHeight - context.offsetHeight`

Note that this still doesn't work if there are nested scrolling elements between the context and the target element.