### PR TITLE
Use attribute `name` as a fallback if `id` is not found

### DIFF
--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -95,8 +95,16 @@ var linkHandler = function(ev) {
     // most browser don't update :target when the history api is used:
     // THIS IS A BUG FROM THE BROWSERS.
     // change the scrolling duration in this call
-    var node = document.getElementById(this.hash.substring(1))
-    if(!node) return; // Do not scroll to non-existing node
+    var hash_name = this.hash.substring(1);
+    var node = document.getElementById(hash_name);
+    if(!node) {
+        var nodes = document.getElementsByName(hash_name); 
+        if (nodes.length > 0) {
+          node = nodes[0];
+        } else {
+          return; // Do not scroll to non-existing node
+        }
+    }
 
     smoothScroll(node, 500, function(el) {
         location.replace('#' + el.id)


### PR DESCRIPTION
If I'm not wrong this is the traditional way (`name` attribute inside `a` tag) hash anchors were used, so maybe a fallback might be useful.