### PR TITLE
If `string` is passed to target, do querySelector

### DIFF
--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -58,6 +58,8 @@ var smoothScroll = function(el, duration, callback, context){
 
     if (typeof el === 'number') {
       var end = parseInt(el);
+    } else if (typeof el === 'string') {
+      var end = getTop(document.querySelector(el), start)
     } else {
       var end = getTop(el, start);
     }


### PR DESCRIPTION
Not tested yet, but I believe this should work. The purpose is pretty clear, to make it somewhat simpler to pass a target that we want.