### PR TITLE
Fix issue of scroll start position when used with a non-window context

### DIFF
--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -54,7 +54,7 @@ var position = function(start, end, elapsed, duration) {
 var smoothScroll = function(el, duration, callback, context){
     duration = duration || 500;
     context = context || window;
-    var start = context.scrollTop || window.pageYOffset;
+    var start = context.scrollTop !== undefined ? context.scrollTop : window.pageYOffset;
 
     if (typeof el === 'number') {
       var end = parseInt(el);


### PR DESCRIPTION
@alicelieutier please have a look to this PR :

This patch aims to fix the issue of the wrong `start` value when used with a non-window context which has `scrollTop` value in zero (e.g. A fixed modal or lightbox).

Say, I have a pop-up fullscreen overlay modal which has `position: fixed`, and I implemented the scrolling behavior on this modal by `smoothScroll`.
And here is the case, when the overlay modal has `scrollTop === 0` and `window.pageYOffset !== 0`
This situation would lead to the WRONG `start` value computed by `smoothScroll` since the `start` variable is defined as:
`var start = context.scrollTop || window.pageYOffset;`
and will always get `window.pageYOffset` as the start position.